### PR TITLE
Added method to retrieve shipping price

### DIFF
--- a/src/Contracts/SendcloudContract.php
+++ b/src/Contracts/SendcloudContract.php
@@ -24,6 +24,8 @@ interface SendcloudContract
 
     public function shippingMethods(array $optionalParameters = []): array;
 
+    public function shippingPrice(int $shippingMethodId, string $fromCountry, int $weight, string $weightUnit, array $optionalParameters = []): array;
+
     public function download(string $url): string;
 
     public function verbose(bool $verbose = true): self;

--- a/src/Sendcloud.php
+++ b/src/Sendcloud.php
@@ -57,14 +57,14 @@ class Sendcloud implements SendcloudContract
     }
 
     public function shippingPrice(
-        int $shipingMethodId,
+        int $shippingMethodId,
         string $fromCountry,
         int $weight,
         string $weightUnit,
         array $optionalParameters = []
     ): array {
         $parameters = [
-            'shipping_method_id' => $shipingMethodId,
+            'shipping_method_id' => $shippingMethodId,
             'from_country'       => $fromCountry,
             'weight'             => $weight,
             'weight_unit'        => $weightUnit,

--- a/src/Sendcloud.php
+++ b/src/Sendcloud.php
@@ -56,6 +56,25 @@ class Sendcloud implements SendcloudContract
         return $this->request('get', self::SHIPPING_METHODS_ENDPOINT, $optionalParameters);
     }
 
+    public function shippingPrice(
+        int $shipingMethodId,
+        string $fromCountry,
+        int $weight,
+        string $weightUnit,
+        array $optionalParameters = []
+    ): array {
+        $parameters = [
+            'shipping_method_id' => $shipingMethodId,
+            'from_country'       => $fromCountry,
+            'weight'             => $weight,
+            'weight_unit'        => $weightUnit,
+        ];
+
+        $parameters = array_merge($parameters, $optionalParameters);
+
+        return $this->request('get', 'shipping-price', $parameters);
+    }
+
     public function download(string $url): string
     {
         $response = Http::withBasicAuth(config('sendcloud.key'), config('sendcloud.secret'))


### PR DESCRIPTION
Method to support Sendcloud's new shipping price API endpoint https://docs.sendcloud.sc/api/v2/shipping/#get-shipping-price.